### PR TITLE
Add version and command line interface option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.9
-long_description: file: README.rst
+long_description = file: README.rst
 long_description_content_type = text/x-rst
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,39 @@
+[metadata]
+name = epcsunspecdemo
+version = attr: epcsunspecdemo.__version__
+description = EPC SunSpec demonstration tool
+author = EPC Power Corporation
+url = https://epcpower.com/
+project_urls =
+    Source=https://github.com/epcpower/sunspec-demo
+license = MIT
+classifiers =
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.9
+long_description_content_type = text/x-rst
+
+[options]
+include_package_data = True
+zip_safe = False
+package_dir = =src
+packages = find:
+install_requires =
+    attrs == 18.2.0
+    click == 7.0
+    gitignoreio == 0.1.5
+    pysunspec == 2.0.0
+    toolz == 0.9.0
+    tqdm == 4.32.1
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+; All the extra tools used to help with the development process.
+development =
+    gitignoreio == 0.1.5
+
+[options.entry_points]
+console_scripts =
+    epcsunspecdemo = epcsunspecdemo.cli:cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.9
+long_description: file: README.rst
 long_description_content_type = text/x-rst
 
 [options]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-import pathlib
 import setuptools
 
 
-setuptools.setup(
-    long_description=pathlib.Path("README.rst").read_text(encoding="utf8"),
-)
+setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -1,46 +1,7 @@
-import os
+import pathlib
 import setuptools
 
 
-def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as file:
-        return file.read()
-
-
-def get_version(rel_path):
-    for line in read(rel_path).splitlines():
-        if line.startswith('__version__'):
-            delim = '"' if '"' in line else "'"
-            return line.split(delim)[1]
-    else:
-        raise RuntimeError("Unable to find version string.")
-
-
 setuptools.setup(
-    name='epcsunspecdemo',
-    version=get_version('./src/epcsunspecdemo/_version.py'),
-    long_description=read('README.rst'),
-    long_description_content_type='text/x-rst',
-    packages=setuptools.find_packages('src'),
-    package_dir={'': 'src'},
-    include_package_data=True,
-    install_requires=[
-        'attrs',
-        'click',
-        'pysunspec',
-        'toolz',
-        'tqdm',
-    ],
-    extras_require={
-        'development': [
-            'gitignoreio',
-        ],
-    },
-    entry_points={
-        'console_scripts': [
-            (
-                'epcsunspecdemo = epcsunspecdemo.cli:cli',
-            ),
-        ],
-    },
+    long_description=pathlib.Path("README.rst").read_text(encoding="utf8"),
 )

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,18 @@ def read(fname):
         return file.read()
 
 
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
 setuptools.setup(
     name='epcsunspecdemo',
+    version=get_version('./src/epcsunspecdemo/_version.py'),
     long_description=read('README.rst'),
     long_description_content_type='text/x-rst',
     packages=setuptools.find_packages('src'),

--- a/src/epcsunspecdemo/__init__.py
+++ b/src/epcsunspecdemo/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for epcsunspecdemo."""
+
+from epcsunspecdemo._version import __version__

--- a/src/epcsunspecdemo/_version.py
+++ b/src/epcsunspecdemo/_version.py
@@ -1,0 +1,3 @@
+# This file is imported from __init__.py and exec'd from setup.py
+
+__version__ = "0.0.0+dev"

--- a/src/epcsunspecdemo/_version.py
+++ b/src/epcsunspecdemo/_version.py
@@ -1,3 +1,4 @@
-# This file is imported from __init__.py and exec'd from setup.py
+# This file is imported from '__init__.py'.
+# The __version__ value must be updated here as part of the release process.
 
 __version__ = "0.0.0+dev"

--- a/src/epcsunspecdemo/cli.py
+++ b/src/epcsunspecdemo/cli.py
@@ -20,6 +20,7 @@ class Config:
 
 
 @click.group()
+@click.version_option(version=epcsunspecdemo.__version__)
 @click.pass_context
 def cli(context):
     context.obj = Config()


### PR DESCRIPTION
Add functionality for the executable command line interface --version option. Add the ability to set an application version. 

The release process will be similar to qtrio, where:
1) a release branch is created, 
2) the _version.py file is updated with an official release version, 
3) the commit is tagged, 
4) "+dev" is added to the version in _version.py, 
5) and then the release branch is merged back into develop (the current master branch). 

Fixes #7