### PR TITLE
multi file executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Archive executable
         uses: actions/upload-artifact@v2
         with:
-          name: executable
-          path: dist/epcsunspecdemo.exe
+          name: epcsunspecdemo
+          path: dist/epcsunspecdemo/*
 
   all:
     name: All

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -61,10 +61,8 @@ pyz = PYZ(
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
     [],
+    exclude_binaries=True,
     name=name,
     debug=False,
     bootloader_ignore_signals=False,
@@ -73,4 +71,15 @@ exe = EXE(
     upx_exclude=[],
     runtime_tmpdir=None,
     console=True,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name=name,
 )


### PR DESCRIPTION
Explore generating a multi file executable instead of a single file executable. The reason is because the generated single file executable is often flagged by virus scanners and the hypothesis is that a multi file executable will not be flagged.