### PR TITLE
fix readme.rst last commit badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      # TODO: cover hotfix, release, master, etc?
-      - develop
+      - main
     tags:
       - v*
   pull_request:

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ EPC SunSpec Demo
    :alt: source on GitHub
    :target: https://github.com/epcpower/sunspec-demo
 
+.. |GitHub| image:: https://img.shields.io/github/workflow/status/epcpower/sunspec-demo/CI/main?color=seagreen&logo=GitHub-Actions&logoColor=whitesmoke
+   :alt: tests on GitHub Actions
+   :target: https://github.com/epcpower/sunspec-demo/actions?query=branch%3Amain
 
 The EPC SunSpec demo implements basic SunSpec communications with EPC converters.
 SunSpec is built on Modbus and works with both Modbus RTU (direct serial) and Modbus TCP connections.

--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,13 @@
 EPC SunSpec Demo
 ================
 
-|GitHub|
+|github actions| |github source|
 
-
-.. |GitHub| image:: https://img.shields.io/github/last-commit/epcpower/sunspec-demo/main.svg
+.. |github source| image:: https://img.shields.io/github/last-commit/epcpower/sunspec-demo/main.svg
    :alt: source on GitHub
    :target: https://github.com/epcpower/sunspec-demo
 
-.. |GitHub| image:: https://img.shields.io/github/workflow/status/epcpower/sunspec-demo/CI/main?color=seagreen&logo=GitHub-Actions&logoColor=whitesmoke
+.. |github actions| image:: https://img.shields.io/github/workflow/status/epcpower/sunspec-demo/CI/main?color=seagreen&logo=GitHub-Actions&logoColor=whitesmoke
    :alt: tests on GitHub Actions
    :target: https://github.com/epcpower/sunspec-demo/actions?query=branch%3Amain
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ EPC SunSpec Demo
 |GitHub|
 
 
-.. |GitHub| image:: https://img.shields.io/github/last-commit/epcpower/sunspec-demo
+.. |GitHub| image:: https://img.shields.io/github/last-commit/epcpower/sunspec-demo/main.svg
    :alt: source on GitHub
    :target: https://github.com/epcpower/sunspec-demo
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ EPC SunSpec Demo
 |GitHub|
 
 
-.. |GitHub| image:: https://img.shields.io/github/last-commit/epcpower/sunspec-demo/develop.svg
+.. |GitHub| image:: https://img.shields.io/github/last-commit/epcpower/sunspec-demo
    :alt: source on GitHub
    :target: https://github.com/epcpower/sunspec-demo
 


### PR DESCRIPTION
The "Last Commit" badge in the `readme.rst` displays as:

![image](https://user-images.githubusercontent.com/77705928/127241856-c5ac85f9-8ba5-4daf-9fb5-215dd5143b5d.png)
